### PR TITLE
Fix visuals of custom positive

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -97,26 +97,86 @@
     "determinePositive": {
       "displayName": "Determine Positive",
       "properties": {
-        "default": {
-          "displayName": "Default",
+        "custom": {
+          "displayName": "Custom",
           "type": {
             "bool": true
           }
         },
-        "custom": {
-          "displayName": "Custom",
+        "when": {
+          "displayName": "When",
+          "type": {
+            "enumeration": [
+              {
+                "value": "<",
+                "displayName": "is less than"
+              },
+              {
+                "value": "<=",
+                "displayName": "is less than or equal to"
+              },
+              {
+                "value": ">",
+                "displayName": "is greater than"
+              },
+              {
+                "value": ">=",
+                "displayName": "is greater than or equal to"
+              },
+              {
+                "value": "===",
+                "displayName": "is"
+              },
+              {
+                "value": "!==",
+                "displayName": "is not"
+              }
+            ]
+          }
+        },
+        "value": {
           "type": {
             "text": true
           }
         },
-        "default2": {
-          "displayName": "Default 2",
+        "custom2": {
+          "displayName": "Custom",
           "type": {
             "bool": true
           }
         },
-        "custom2": {
-          "displayName": "Custom 2",
+        "when2": {
+          "displayName": "When",
+          "type": {
+            "enumeration": [
+              {
+                "value": "<",
+                "displayName": "is less than"
+              },
+              {
+                "value": "<=",
+                "displayName": "is less than or equal to"
+              },
+              {
+                "value": ">",
+                "displayName": "is greater than"
+              },
+              {
+                "value": ">=",
+                "displayName": "is greater than or equal to"
+              },
+              {
+                "value": "===",
+                "displayName": "is"
+              },
+              {
+                "value": "!==",
+                "displayName": "is not"
+              }
+            ]
+          }
+        },
+        "value2": {
           "type": {
             "text": true
           }
@@ -222,12 +282,14 @@
           "type": {
             "text": true
           }
-        },"header2": {
+        },
+        "header2": {
           "displayName": "Header 2",
           "type": {
             "text": true
           }
-        },"header3": {
+        },
+        "header3": {
           "displayName": "Header 3",
           "type": {
             "text": true

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -958,9 +958,11 @@ module powerbi.extensibility.visual {
 
                         var offSetForCategory = 8;
 
+
+                        console.log(this.activeFontSize);
                         //Fill up the space next to the category with lines
-                        s.centeredLines[0].attr("x1", s.posX).attr("x2", s.posX + ((actualWidth - s.categorySize) / 2) - offSetForCategory).attr("stroke-width", 2).attr("stroke", this.visualCurrentSettings.scroller.pForeColor.solid.color);
-                        s.centeredLines[1].attr("x1", s.posX + ((actualWidth + s.categorySize) / 2) + offSetForCategory).attr("x2", s.posX + actualWidth).attr("stroke-width", 2).attr("stroke", this.visualCurrentSettings.scroller.pForeColor.solid.color);
+                        s.centeredLines[0].attr("x1", s.posX).attr("x2", s.posX + ((actualWidth - s.categorySize) / 2) - offSetForCategory).attr("stroke-width", this.activeFontSize / 10).attr("stroke", this.visualCurrentSettings.scroller.pForeColor.solid.color);
+                        s.centeredLines[1].attr("x1", s.posX + ((actualWidth + s.categorySize) / 2) + offSetForCategory).attr("x2", s.posX + actualWidth).attr("stroke-width", this.activeFontSize / 10).attr("stroke", this.visualCurrentSettings.scroller.pForeColor.solid.color);
                     }
 
                     var posX = s.posX;

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -35,6 +35,12 @@ module powerbi.extensibility.visual {
         measureDeviationFormatted: string[];
     };
 
+    interface customPositive {
+        use: boolean;
+        when: string;
+        value: string;
+    }
+
     interface VisualSettings {
         scroller: {
             pShouldAutoSizeFont: boolean;
@@ -52,8 +58,7 @@ module powerbi.extensibility.visual {
         },
 
         determinePositive: {
-            default: boolean[];
-            custom: string[];
+            custom: customPositive[];
         },
 
         headers: {
@@ -117,8 +122,7 @@ module powerbi.extensibility.visual {
                 pInterval: 50
             },
             determinePositive: {
-                default: [true, true],
-                custom: ["", ""],
+                custom: []
             },
             headers: {
                 headers: []
@@ -151,8 +155,16 @@ module powerbi.extensibility.visual {
                 pInterval: getValue<number>(objects, 'scroller', 'pInterval', defaultSettings.scroller.pInterval)
             },
             determinePositive: {
-                default: [getValue<boolean>(objects, 'determinePositive', 'default', defaultSettings.determinePositive.default[0]), getValue<boolean>(objects, 'determinePositive', 'default2', undefined)].filter(x => x !== undefined),
-                custom: [getValue<string>(objects, 'determinePositive', 'custom', defaultSettings.determinePositive.custom[0]), getValue<string>(objects, 'determinePositive', 'custom2', undefined)].filter(x => x !== undefined)
+                custom: [{
+                    use: getValue<boolean>(objects, 'determinePositive', "custom", false),
+                    when: getValue<string>(objects, 'determinePositive', "when", ">"),
+                    value: getValue<string>(objects, 'determinePositive', "value", undefined)
+                },
+                {
+                    use: getValue<boolean>(objects, 'determinePositive', "custom2", false),
+                    when: getValue<string>(objects, 'determinePositive', "when2", ">"),
+                    value: getValue<string>(objects, 'determinePositive', "value2", undefined)
+                }]
             },
             headers: {
                 headers: [getValue<string>(objects, 'headers', 'header1', ""), getValue<string>(objects, 'headers', 'header2', undefined), getValue<string>(objects, 'headers', 'header3', undefined)].filter(x => x !== undefined)
@@ -545,16 +557,29 @@ module powerbi.extensibility.visual {
         }
 
         private isPositiveValue(data, settings, index) {
-            if (settings.determinePositive.default[index])
+            console.log(data);
+
+            if (settings.determinePositive.custom[index].use === false)
                 return data >= 0;
 
-            if (index < settings.determinePositive.custom.length && settings.determinePositive.custom[index].trim().length > 0) {
-                var func = new Function("x", "return x " + settings.determinePositive.custom[index]);
+            var condition = this.combineConditionAndValue(settings.determinePositive.custom[index].when, settings.determinePositive.custom[index].value);
+
+            if (condition !== undefined) {
+                var func = new Function("x", "return x " + condition);
                 return func(data);
             }
 
             return data >= 0;
         }
+
+        private combineConditionAndValue(condition, value) {
+            if (condition === undefined || value === undefined) {
+                return undefined;
+            }
+    
+            return " " + condition + " " + value;
+        }
+    
 
         public getMetaDataColumnForMeasureIndex(dataView: DataView, measureIndex: number) {
             var addCol = 0;
@@ -595,15 +620,18 @@ module powerbi.extensibility.visual {
 
                     if (this.visualDataPoints[0] !== undefined && this.visualDataPoints[0].measureDeviation.length === 2) {
                         properties = {
-                            default: this.visualCurrentSettings.determinePositive.default[0],
-                            custom: this.visualCurrentSettings.determinePositive.custom[0],
-                            default2: this.visualCurrentSettings.determinePositive.default[1],
-                            custom2: this.visualCurrentSettings.determinePositive.custom[1]
+                            custom: this.visualCurrentSettings.determinePositive.custom[0].use,
+                            when: this.visualCurrentSettings.determinePositive.custom[0].when,
+                            value: this.visualCurrentSettings.determinePositive.custom[0].value,
+                            custom2: this.visualCurrentSettings.determinePositive.custom[1].use,
+                            when2: this.visualCurrentSettings.determinePositive.custom[1].when,
+                            value2: this.visualCurrentSettings.determinePositive.custom[1].value,
                         };
                     } else {
                         properties = {
-                            default: this.visualCurrentSettings.determinePositive.default[0],
-                            custom: this.visualCurrentSettings.determinePositive.custom[0]
+                            custom: this.visualCurrentSettings.determinePositive.custom[0].use,
+                            when: this.visualCurrentSettings.determinePositive.custom[0].when,
+                            value: this.visualCurrentSettings.determinePositive.custom[0].value
                         };
                     }
 
@@ -841,7 +869,7 @@ module powerbi.extensibility.visual {
 
                         var widthBeforeSpiltChar;
 
-                        s.svgSel.each(function() {
+                        s.svgSel.each(function () {
                             widthBeforeSpiltChar = this.getBBox().width;
                         });
 
@@ -862,12 +890,12 @@ module powerbi.extensibility.visual {
                             s.sCategory.attr("y", y - this.getBBox().height);
 
                             var yLines = y - (this.getBBox().height * 0.75);
-                            s.centeredLines[0].attr("y1", yLines).attr("y2",  yLines);
-                            s.centeredLines[1].attr("y1",  yLines).attr("y2",  yLines);
+                            s.centeredLines[0].attr("y1", yLines).attr("y2", yLines);
+                            s.centeredLines[1].attr("y1", yLines).attr("y2", yLines);
 
                             //The actual width of the element will be the largest element between the different levels
-                            s.actualWidth = d3.max([widthBeforeSpiltChar - offsetOfCategoryAndHeaders ,
-                                s.categorySize
+                            s.actualWidth = d3.max([widthBeforeSpiltChar - offsetOfCategoryAndHeaders,
+                            s.categorySize
                             ]);
 
                             //Use s.offset to get the size of the split char in order to take it into consideration for the centering
@@ -924,13 +952,14 @@ module powerbi.extensibility.visual {
                         //Center the category
                         s.sCategory.attr("x", s.posX + (actualWidth - s.categorySize) / 2);
 
+                        var offSetForCategory = 8;
+
                         //Fill up the space next to the category with lines
-                        s.centeredLines[0].attr("x1", s.posX).attr("x2", s.posX + (actualWidth - s.categorySize) / 2).attr("stroke-width", 2).attr("stroke", this.visualCurrentSettings.scroller.pForeColor.solid.color);
-                        s.centeredLines[1].attr("x1", s.posX + ((actualWidth + s.categorySize) / 2)).attr("x2", s.posX + actualWidth).attr("stroke-width", 2).attr("stroke", this.visualCurrentSettings.scroller.pForeColor.solid.color);
+                        s.centeredLines[0].attr("x1", s.posX).attr("x2", s.posX + ((actualWidth - s.categorySize) / 2) - offSetForCategory).attr("stroke-width", 2).attr("stroke", this.visualCurrentSettings.scroller.pForeColor.solid.color);
+                        s.centeredLines[1].attr("x1", s.posX + ((actualWidth + s.categorySize) / 2) + offSetForCategory).attr("x2", s.posX + actualWidth).attr("stroke-width", 2).attr("stroke", this.visualCurrentSettings.scroller.pForeColor.solid.color);
                     }
 
                     var posX = s.posX;
-                    debugger;
                     //If the category is the largest part, then we need to center the stocks information based on that
                     if (s.actualWidth === s.categorySize) {
                         posX += s.categorySize / 2;

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -887,9 +887,13 @@ module powerbi.extensibility.visual {
                                 s.sHeaders[i].attr("y", y - offset);
                             }
 
-                            s.sCategory.attr("y", y - this.getBBox().height);
+                            //Keep track of the category height and y position to use it to place the lines
+                            var categoryHeight = y - this.getBBox().height;
+                            offset = this.getBBox().height;
+                            s.sCategory.attr("y", categoryHeight);
 
-                            var yLines = y - (this.getBBox().height * 0.75);
+                            var temp = this.getBBox().height;
+                            var yLines = categoryHeight - ((temp - offset) * 0.4);
                             s.centeredLines[0].attr("y1", yLines).attr("y2", yLines);
                             s.centeredLines[1].attr("y1", yLines).attr("y2", yLines);
 


### PR DESCRIPTION
Modify the UI for the formatting tab "Custom Positive" making it more user friendly and resemble the "Advanced Filter" that is already implemented in Power Bi. Modify the center line in order for it's height to be more consistent from when the headers are present and when they are not present. Finally, change the stroke-width of the line to be correlated to the size of the text, meaning it will grow when the text does.